### PR TITLE
Add disconnect method to connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -86,4 +86,8 @@ module.exports = class Connection extends EventEmitter {
 
     self._connection.open()
   }
+
+  disconnect () {
+    this._connection.close()
+  }
 }


### PR DESCRIPTION
Calling the disconnect method gave me the following error:

dsmr-api/parser/index.js:110
    self._connection.disconnect()

and I was unable to call connect again. I added a disconnect to the connection.js which closes the serial port connection. With this change, I could connect again with different settings  after I closed the original connection.